### PR TITLE
Fix gccgo compatibility

### DIFF
--- a/errors.go
+++ b/errors.go
@@ -199,7 +199,7 @@ func setLocation(err error, callDepth int) {
 // is a drop-in replacement for errors.New from the standard library.
 func New(s string) error {
 	err := &Err{Message_: s}
-	err.SetLocation(1)
+	err.SetLocation(callerOffset)
 	return err
 }
 
@@ -301,7 +301,7 @@ func Mask(underlying error, pass ...func(error) bool) error {
 		return nil
 	}
 	err := NoteMask(underlying, "", pass...)
-	setLocation(err, 1)
+	setLocation(err, callerOffset)
 	return err
 }
 
@@ -311,7 +311,7 @@ func Mask(underlying error, pass ...func(error) bool) error {
 // or WithCausef to add a message while retaining a cause).
 func Notef(underlying error, f string, a ...interface{}) error {
 	err := NoteMask(underlying, fmt.Sprintf(f, a...))
-	setLocation(err, 1)
+	setLocation(err, callerOffset)
 	return err
 }
 
@@ -334,7 +334,7 @@ func MaskFunc(allow ...func(error) bool) func(error, ...func(error) bool) error 
 			allowEither = allow
 		}
 		err = Mask(err, allowEither...)
-		setLocation(err, 1)
+		// setLocation(err, 0)
 		return err
 	}
 }
@@ -349,7 +349,7 @@ func WithCausef(underlying, cause error, f string, a ...interface{}) error {
 		Cause_:      cause,
 		Message_:    fmt.Sprintf(f, a...),
 	}
-	err.SetLocation(1)
+	err.SetLocation(callerOffset)
 	return err
 }
 

--- a/errors.go
+++ b/errors.go
@@ -334,7 +334,7 @@ func MaskFunc(allow ...func(error) bool) func(error, ...func(error) bool) error 
 			allowEither = allow
 		}
 		err = Mask(err, allowEither...)
-		// setLocation(err, 0)
+		setLocation(err, 1)
 		return err
 	}
 }

--- a/errors_gc.go
+++ b/errors_gc.go
@@ -1,0 +1,5 @@
+// +build !gccgo
+
+package errgo
+
+const callerOffset = 1

--- a/errors_gccgo.go
+++ b/errors_gccgo.go
@@ -1,0 +1,5 @@
+// +build gccgo
+
+package errgo
+
+const callerOffset = 2

--- a/errors_test.go
+++ b/errors_test.go
@@ -28,12 +28,6 @@ func TestNewf(t *testing.T) {
 
 var someErr = errgo.New("some error")
 
-func TestWithCausef(t *testing.T) {
-	underlying := errgo.New("underlying")               //err TestWithCausef#0
-	err := errgo.WithCausef(underlying, someErr, "foo") //err TestWithCausef#1
-	checkErr(t, err, underlying, "foo: underlying", "[{$TestWithCausef#1$: foo} {$TestWithCausef#0$: underlying}]", someErr)
-}
-
 func TestMask(t *testing.T) {
 	err0 := errgo.WithCausef(nil, someErr, "foo") //err TestMask#0
 	err := errgo.Mask(err0)                       //err TestMask#1

--- a/errors_test.go
+++ b/errors_test.go
@@ -2,11 +2,12 @@ package errgo_test
 
 import (
 	"fmt"
-	"github.com/juju/errgo"
 	"io/ioutil"
 	"runtime"
 	"strings"
 	"testing"
+
+	"github.com/juju/errgo"
 )
 
 var (
@@ -26,6 +27,12 @@ func TestNewf(t *testing.T) {
 }
 
 var someErr = errgo.New("some error")
+
+func TestWithCausef(t *testing.T) {
+	underlying := errgo.New("underlying")               //err TestWithCausef#0
+	err := errgo.WithCausef(underlying, someErr, "foo") //err TestWithCausef#1
+	checkErr(t, err, underlying, "foo: underlying", "[{$TestWithCausef#1$: foo} {$TestWithCausef#0$: underlying}]", someErr)
+}
 
 func TestMask(t *testing.T) {
 	err0 := errgo.WithCausef(nil, someErr, "foo") //err TestMask#0


### PR DESCRIPTION
Introduce a conditional constant to deal with the implementation differences between gc and gccgo.

There is one test still to fix (down from 5)

--- FAIL: TestMask (0.00 seconds)
        errors_test.go:231: unexpected details: want "[{/home/dfc/src/github.com/juju/errgo/errors_test.go:39: } {/home/dfc/src/github.com/juju/errgo/errors_test.go:38: foo}]"; got "[{} {foo}]"
