### PR TITLE
Fix two errors found by go vet

### DIFF
--- a/errors.go
+++ b/errors.go
@@ -87,7 +87,7 @@ func (e *Err) Message() string {
 // Error implements error.Error.
 func (e *Err) Error() string {
 	switch {
-	case e.Message_ == "" && e.Underlying == nil:
+	case e.Message_ == "" && e.Underlying_ == nil:
 		return "<no error>"
 	case e.Message_ == "":
 		return e.Underlying_.Error()

--- a/errors_test.go
+++ b/errors_test.go
@@ -220,7 +220,7 @@ func (*errorsSuite) TestMatch(c *gc.C) {
 }
 
 func (*errorsSuite) TestLocation(c *gc.C) {
-	loc := errgo.Location{"foo", 35}
+	loc := errgo.Location{File: "foo", Line: 35}
 	c.Assert(loc.String(), gc.Equals, "foo:35")
 }
 


### PR DESCRIPTION
One major, one minor.

errors.go:90: comparison of function Underlying == nil is always false
errors_test.go:223: errgo.Location composite literal uses unkeyed fields
