### PR TITLE
Fixed outdated import

### DIFF
--- a/errors_test.go
+++ b/errors_test.go
@@ -10,7 +10,7 @@ import (
 	"strings"
 	"testing"
 
-	gc "launchpad.net/gocheck"
+	gc "gopkg.in/check.v1"
 
 	"github.com/juju/errgo"
 )


### PR DESCRIPTION
This PR changes the import of gocheck from launchpad to github.
